### PR TITLE
Revert commits

### DIFF
--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -104,7 +104,7 @@ def get(ids_or_query):
         bug_id = int(bug["id"])
 
         if bug_id not in new_bugs:
-            new_bugs[bug_id] = {}
+            new_bugs[bug_id] = dict()
 
         new_bugs[bug_id].update(bug)
 
@@ -112,7 +112,7 @@ def get(ids_or_query):
         bug_id = int(bug_id)
 
         if bug_id not in new_bugs:
-            new_bugs[bug_id] = {}
+            new_bugs[bug_id] = dict()
 
         new_bugs[bug_id]["comments"] = bug["comments"]
 
@@ -120,7 +120,7 @@ def get(ids_or_query):
         bug_id = int(bug_id)
 
         if bug_id not in new_bugs:
-            new_bugs[bug_id] = {}
+            new_bugs[bug_id] = dict()
 
         new_bugs[bug_id]["attachments"] = bug
 
@@ -128,7 +128,7 @@ def get(ids_or_query):
         bug_id = int(bug["id"])
 
         if bug_id not in new_bugs:
-            new_bugs[bug_id] = {}
+            new_bugs[bug_id] = dict()
 
         new_bugs[bug_id]["history"] = bug["history"]
 

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -408,7 +408,7 @@ class Model:
         print("Model trained")
 
         feature_names = self.get_human_readable_feature_names()
-        if self.calculate_importance and feature_names:
+        if self.calculate_importance and len(feature_names):
             explainer = shap.TreeExplainer(self.clf)
             shap_values = explainer.shap_values(X_train)
 

--- a/bugbug/models/rcatype.py
+++ b/bugbug/models/rcatype.py
@@ -147,7 +147,7 @@ class RCATypeModel(BugModel):
             )
 
             if rca_whiteboard_split[1] not in self.RCA_LIST:
-                logger.warning(rca_whiteboard_split[1], " not in RCA_LIST")
+                logger.warning(rca_whiteboard_split[1] + " not in RCA_LIST")
             else:
                 rca.append(rca_whiteboard_split[1])
         return rca

--- a/bugbug/models/testselect.py
+++ b/bugbug/models/testselect.py
@@ -249,8 +249,8 @@ class TestSelectModel(Model):
             commit_data,
             push_num,
             all_runnables,
-            (),
-            (),
+            tuple(),
+            tuple(),
         ):
             commit_test = commit_data.copy()
             commit_test["test_job"] = data

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -47,7 +47,7 @@ CommitDict = NewType("CommitDict", dict)
 
 code_analysis_server: Optional[rust_code_analysis_server.RustCodeAnalysisServer] = None
 
-hg_servers = []
+hg_servers = list()
 hg_servers_lock = threading.Lock()
 thread_local = threading.local()
 
@@ -705,7 +705,7 @@ def _transform(commit):
 
 def hg_log(hg: hglib.client, revs: List[bytes]) -> Tuple[Commit, ...]:
     if len(revs) == 0:
-        return ()
+        return tuple()
 
     template = "{node}\\0{author}\\0{desc}\\0{bug}\\0{backedoutby}\\0{author|email}\\0{pushdate|hgdate}\\0{reviewers}\\0{backsoutnodes}\\0"
 
@@ -905,7 +905,7 @@ def calculate_experiences(
     ) -> None:
         for commit_type in ("", "backout"):
             exp_queues = tuple(
-                get_experience(experience_type, commit_type, item, day, ())
+                get_experience(experience_type, commit_type, item, day, tuple())
                 for item in items
             )
             all_commit_lists = tuple(exp_queues[i][day] for i in range(len(items)))
@@ -919,8 +919,8 @@ def calculate_experiences(
                 )
             )
 
-            all_commits = set(sum(all_commit_lists, ()))
-            timespan_commits = set(sum(timespan_commit_lists, ()))
+            all_commits = set(sum(all_commit_lists, tuple()))
+            timespan_commits = set(sum(timespan_commit_lists, tuple()))
 
             commit.set_experience(
                 experience_type,
@@ -1105,7 +1105,7 @@ def close_component_mapping():
 
 def hg_log_multi(repo_dir: str, revs: List[bytes]) -> Tuple[Commit, ...]:
     if len(revs) == 0:
-        return ()
+        return tuple()
 
     cpu_count = os.cpu_count()
     threads_num = cpu_count + 1 if cpu_count is not None else 1
@@ -1151,7 +1151,7 @@ def download_commits(
 
         if len(revs) == 0:
             logger.info("No commits to analyze")
-            return ()
+            return tuple()
 
         first_pushdate = get_first_pushdate(repo_dir)
 

--- a/http_service/bugbug_http/download_models.py
+++ b/http_service/bugbug_http/download_models.py
@@ -22,8 +22,8 @@ def download_models():
         except FileNotFoundError:
             if ALLOW_MISSING_MODELS:
                 LOGGER.info(
-                    "Missing %r model, skipping because ALLOW_MISSING_MODELS is set",
-                    model_name,
+                    "Missing %r model, skipping because ALLOW_MISSING_MODELS is set"
+                    % model_name
                 )
                 return None
             else:

--- a/http_service/bugbug_http/models.py
+++ b/http_service/bugbug_http/models.py
@@ -78,7 +78,7 @@ def classify_bug(model_name: str, bug_ids: Sequence[int], bugzilla_token: str) -
     model = MODEL_CACHE.get(model_name)
 
     if not model:
-        LOGGER.info("Missing model %r, aborting", model_name)
+        LOGGER.info("Missing model %r, aborting" % model_name)
         return "NOK"
 
     model_extra_data = model.get_extra_data()

--- a/scripts/commit_classifier.py
+++ b/scripts/commit_classifier.py
@@ -361,7 +361,7 @@ class CommitClassifier(object):
             )
             reviewers = set(reviewer["fields"]["username"] for reviewer in reviewers)
 
-            if reviewers:
+            if len(reviewers):
                 message = replace_reviewers(message, reviewers)
 
             logger.info(


### PR DESCRIPTION
- Pass string format arguments as logging method parameters
- Remove length check in favour of truthiness of the object
- Use literal syntax instead of function calls to create data structure